### PR TITLE
Minor v5 cleanup

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,56 +1,16 @@
-/*
- * Keep in sync with `assets/stylesheets/_bootstrap.scss` from
- * `bootstrap-rubygem`.
- */
-
+// 1. Include functions & variables first
 @import "bootstrap/functions";
-
-$custom-colors: ( "bootstrap": #563d7c, "simpleform": #00617f );
-
 @import "bootstrap/variables";
-@import "bootstrap/mixins";
 
+$custom-colors: (
+  "bootstrap": #563d7c,
+  "simpleform": #00617f
+);
 $theme-colors: map-merge($theme-colors, $custom-colors);
 
-@import "bootstrap/utilities";
+// Custom bootstrap variables must be set or imported *before* bootstrap.
+@import "bootstrap";
 
-// Layout & components
-@import "bootstrap/root";
-@import "bootstrap/reboot";
-@import "bootstrap/type";
-@import "bootstrap/images";
-@import "bootstrap/containers";
-@import "bootstrap/grid";
-@import "bootstrap/tables";
-@import "bootstrap/forms";
-@import "bootstrap/buttons";
-@import "bootstrap/transitions";
-@import "bootstrap/dropdown";
-@import "bootstrap/button-group";
-@import "bootstrap/nav";
-@import "bootstrap/navbar";
-@import "bootstrap/card";
-@import "bootstrap/accordion";
-@import "bootstrap/breadcrumb";
-@import "bootstrap/pagination";
-@import "bootstrap/badge";
-@import "bootstrap/alert";
-@import "bootstrap/progress";
-@import "bootstrap/list-group";
-@import "bootstrap/close";
-@import "bootstrap/toasts";
-@import "bootstrap/modal";
-@import "bootstrap/tooltip";
-@import "bootstrap/popover";
-@import "bootstrap/carousel";
-@import "bootstrap/spinners";
-@import "bootstrap/offcanvas";
-
-// Helpers
-@import "bootstrap/helpers";
-
-// Utilities
-@import "bootstrap/utilities/api";
 
 // App sections
 @import "application/breadcrumb";

--- a/app/views/examples/input_groups/_bootstrap.html.erb
+++ b/app/views/examples/input_groups/_bootstrap.html.erb
@@ -4,7 +4,7 @@
   <div class="mb-3">
     <label for="exampleInputName" class="form-label">Name</label>
     <div class="input-group has-validation">
-      <span class="input-group-text" id="basic-addon1">@</span>
+      <span class="input-group-text">@</span>
       <input type="text" class="form-control" id="exampleInputName" placeholder="Your name" required>
       <div class="invalid-feedback">Name can't be blank</div>
       <div class="valid-feedback">Looks good!</div>
@@ -15,9 +15,9 @@
   <div class="mb-3">
     <label for="exampleInputEmail" class="form-label">Email</label>
     <div class="input-group has-validation">
-      <span class="input-group-text" id="basic-addon1">example-</span>
+      <span class="input-group-text">example-</span>
       <input type="email" class="form-control" id="exampleInputEmail" placeholder="Enter email" autocomplete="email" required>
-      <span class="input-group-text" id="basic-addon1">@gmail.com</span>
+      <span class="input-group-text">@gmail.com</span>
       <div class="invalid-feedback">Email can't be blank</div>
       <div class="valid-feedback">Looks good!</div>
     </div>
@@ -28,7 +28,7 @@
     <label for="exampleInputPassword" class="form-label">Password</label>
     <div class="input-group has-validation">
       <input type="password" class="form-control" id="exampleInputPassword" placeholder="Password" autocomplete="current-password" required>
-      <span class="input-group-text" id="basic-addon1">🙊</span>
+      <span class="input-group-text">🙊</span>
       <div class="invalid-feedback">Please provide a valid value.</div>
       <div class="valid-feedback">Looks good!</div>
     </div>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -302,7 +302,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: 'form-label'
-    b.wrapper :input_group_tag, class: 'input-group has-validation' do |ba|
+    b.wrapper :input_group_tag, class: 'input-group' do |ba|
       ba.optional :prepend
       ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
       ba.optional :append

--- a/test/simple_form-bootstrap/input_group_test.rb
+++ b/test/simple_form-bootstrap/input_group_test.rb
@@ -11,7 +11,7 @@ class InputGroupFormTest < ActionView::TestCase
     expected = <<-HTML
       <div class="mb-3 string required user_name">
         <label class="form-label string required" for="user_name">Name <abbr title="required">*</abbr></label>
-        <div class="input-group has-validation">
+        <div class="input-group">
           <span class="input-group-text">$</span>
           <input class="form-control string required" id="user_name" name="user[name]" placeholder="Your name" type="text"/>
         </div>
@@ -26,7 +26,7 @@ class InputGroupFormTest < ActionView::TestCase
     expected = <<-HTML
       <div class="mb-3 string required user_name">
         <label class="form-label string required" for="user_name">Name <abbr title="required">*</abbr></label>
-        <div class="input-group has-validation">
+        <div class="input-group">
           <input class="form-control string required" id="user_name" name="user[name]" placeholder="Your name" type="text"/>
           <span class="input-group-text">.00</span>
         </div>
@@ -41,7 +41,7 @@ class InputGroupFormTest < ActionView::TestCase
     expected = <<-HTML
       <div class="mb-3 string required user_name">
         <label class="form-label string required" for="user_name">Name <abbr title="required">*</abbr></label>
-        <div class="input-group has-validation">
+        <div class="input-group">
           <span class="input-group-text">$</span>
           <input class="form-control string required" id="user_name" name="user[name]" placeholder="Your name" type="text"/>
           <span class="input-group-text">.00</span>


### PR DESCRIPTION
minor cleanup after the bootstrap v5 update. 
I've noticed an issue with the `input_group` and rounded borders

* remove static id attributes
* simplify application.scss
  * import bootstrap library
  * reduce maintenance
  * via: https://github.com/twbs/bootstrap-rubygem
* fix issues with border-radius on input_groups
* fix input_group tests

/cc @mhw 